### PR TITLE
Depend on ES6 version of color-name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0"
+        "color-name": "^2.0.0"
       },
       "devDependencies": {
         "tape": "^4.7.0"
@@ -32,9 +32,12 @@
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -358,9 +361,9 @@
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/colorjs/color-parse",
   "dependencies": {
-    "color-name": "^1.0.0"
+    "color-name": "^2.0.0"
   },
   "devDependencies": {
     "tape": "^4.7.0"


### PR DESCRIPTION
Color-parse is published as ES6, however it currently depends on a commonjs package: color-name.

This PR simply updates the dependency to color-name v2, which has been published as ES6 module.

This is important to allow loading of color-parse without a bundler.
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap

Here is the error in chromium:
```
index.js:4 Uncaught SyntaxError: The requested module 'color-name' does not provide an export named 'default' (at index.js:4:8)
```
And here is the context: https://github.com/geoblocks/mapfishprint/pull/25/files#diff-04feb74cf6745156a2f60991cb994548b928a1cd8facec6d1844cd5169eb8479R8-R23